### PR TITLE
Release version 0.1.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.tag.outputs.version }}
-          release_name: ${{ steps.tag.outputs.version }}
+          tag_name: ${{ steps.version.outputs.version }}
+          release_name: ${{ steps.version.outputs.version }}
           body: |
             ${{ steps.find-pr.outputs.body }}
           draft: false

--- a/asymmetric/__init__.py
+++ b/asymmetric/__init__.py
@@ -4,5 +4,5 @@ Init file for the asymmetric module.
 
 from asymmetric.core import asymmetric_object as asymmetric
 
-version_info = (0, 1, 2)
+version_info = (0, 1, 3)
 __version__ = ".".join([str(x) for x in version_info])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asymmetric"
-version = "0.1.2"
+version = "0.1.3"
 description = "The async framework that calls you back! Enable ridiculously fast and easy module-to-API transformations. Learn in minutes, implement in seconds."
 license = "MIT"
 authors = ["Daniel Leal <dlleal@uc.cl>"]


### PR DESCRIPTION
# Version 0.1.3 🎉

Kind of a _bis_, `0.1.2` wasn't properly released.

## Additions

- Add type annotations to the whole codebase
- Add a fair amount of tests
- Add a **very basic** CLI that is capable of responding to `asymmetric --version`

## Changes

- Change the `HTTP` response code for _callback_ endpoints from `200` to `202`
- Remove `jsonschema` as a dev-dependency

## Fixes

- Fix some `README.md` typos