### PR TITLE
Release version 0.1.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo ::set-output name=version::$(poetry run asymmetric --version | cut -d' ' -f3)
+        run: echo ::set-output name=version::$(poetry run asymmetric --version-number)
 
       - name: Get Pull Request data
         uses: jwalton/gh-find-current-pr@v1

--- a/asymmetric/__init__.py
+++ b/asymmetric/__init__.py
@@ -4,5 +4,5 @@ Init file for the asymmetric module.
 
 from asymmetric.core import asymmetric_object as asymmetric
 
-version_info = (0, 1, 4)
+version_info = (0, 1, 5)
 __version__ = ".".join([str(x) for x in version_info])

--- a/asymmetric/cli/core.py
+++ b/asymmetric/cli/core.py
@@ -23,10 +23,20 @@ def generate_parser() -> ArgumentParser:
 
     # Add version command
     parser.add_argument(
-        "-v",
+        "-V",
         "--version",
         action="version",
+        help="show verbose program's version number and exit",
         version=f"asymmetric version {asymmetric.__version__}",
+    )
+
+    # Add version number command
+    parser.add_argument(
+        "-v",
+        "--version-number",
+        action="version",
+        help="show program's version number and exit",
+        version=f"{asymmetric.__version__}",
     )
 
     return parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asymmetric"
-version = "0.1.4"
+version = "0.1.5"
 description = "The async framework that calls you back! Enable ridiculously fast and easy module-to-API transformations. Learn in minutes, implement in seconds."
 license = "MIT"
 authors = ["Daniel Leal <dlleal@uc.cl>"]


### PR DESCRIPTION
# Version 0.1.5 🎉

Kind of a _bis_, `0.1.2`, `0.1.3` and `0.1.4` weren't properly released.

## Additions

- Add type annotations to the whole codebase
- Add a fair amount of tests
- Add a **very basic** CLI that is capable of responding to `asymmetric --version` with the verbose version and to `asymmetric --version-number` with just the version number.

## Changes

- Change the `HTTP` response code for _callback_ endpoints from `200` to `202`
- Remove `jsonschema` as a dev-dependency

## Fixes

- Fix some `README.md` typos