### PR TITLE
Release version 0.1.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+
       - name: Install Poetry
         run: make get-poetry
 
@@ -52,7 +57,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo ::set-output name=version::$(poetry run asymmetric --version-number)
+        run: echo ::set-output name=version::$(poetry run asymmetric --version | rev | cut -d' ' -f1 | rev)
 
       - name: Get Pull Request data
         uses: jwalton/gh-find-current-pr@v1

--- a/asymmetric/__init__.py
+++ b/asymmetric/__init__.py
@@ -4,5 +4,5 @@ Init file for the asymmetric module.
 
 from asymmetric.core import asymmetric_object as asymmetric
 
-version_info = (0, 1, 5)
+version_info = (0, 1, 6)
 __version__ = ".".join([str(x) for x in version_info])

--- a/asymmetric/cli/core.py
+++ b/asymmetric/cli/core.py
@@ -23,20 +23,10 @@ def generate_parser() -> ArgumentParser:
 
     # Add version command
     parser.add_argument(
-        "-V",
+        "-v",
         "--version",
         action="version",
-        help="show verbose program's version number and exit",
         version=f"asymmetric version {asymmetric.__version__}",
-    )
-
-    # Add version number command
-    parser.add_argument(
-        "-v",
-        "--version-number",
-        action="version",
-        help="show program's version number and exit",
-        version=f"{asymmetric.__version__}",
     )
 
     return parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asymmetric"
-version = "0.1.5"
+version = "0.1.6"
 description = "The async framework that calls you back! Enable ridiculously fast and easy module-to-API transformations. Learn in minutes, implement in seconds."
 license = "MIT"
 authors = ["Daniel Leal <dlleal@uc.cl>"]


### PR DESCRIPTION
# Version 0.1.6 🎉

Kind of a _bis_, `0.1.2`, `0.1.3`, `0.14` and `0.1.5` weren't properly released. **This time for good**.

## Additions

- Add type annotations to the whole codebase
- Add a fair amount of tests
- Add a **very basic** CLI that is capable of responding to `asymmetric --version`.

## Changes

- Change the `HTTP` response code for _callback_ endpoints from `200` to `202`
- Remove `jsonschema` as a dev-dependency

## Fixes

- Fix some `README.md` typos