### PR TITLE
Fix server stops on initialization errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _The async framework that calls you back_! ✨ Enable ridiculously fast and easy
 
 Raw developing speed and ease of use, that's why. `asymmetric` is based on **[Starlette](https://github.com/encode/starlette)** ✨! While `Starlette` is a powerful tool to have, getting it to work from scratch can be a bit of a pain, especially if you have never used it before. The idea behind `asymmetric` is to be able to take any module **already written** and transform it into a working API in a matter of minutes, instead of having to design the module ground-up to work with `Starlette` (it can also be used to build an API from scratch really fast). With `asymmetric`, you will also get some neat features, namely:
 
-- Auto logging.
+- Auto logging (configure logs with the `LOG_FILE` and `LOG_LEVEL` environmental variables).
 - Server-side error detection and exception handling.
 - **Asynchronous callback endpoints** to make a request, terminate the request **immediately** and then have the server make a request to a _callback_ endpoint with the results! ✨
 - ~~Auto-generated `/docs` endpoint for your API with **interactive documentation**.~~ **[UNDER CONSTRUCTION]**

--- a/README.md
+++ b/README.md
@@ -265,7 +265,6 @@ By default, you can `GET` the `/docs` endpoint (using a browser) to access to **
 
 - _Automagic_ OpenAPI spec isn't being generated rigth now, so that's missing from the library. It will soon be added, though, as it is a very useful _feature_.
 - Parse callback `URL`s to make sure that they are valid `URL`s, and fail if they aren't.
-- On some initialization errors, the server should stop to _avoid avoidable errors_. Right now, the method to stop the server really does nothing, so that's something that should be addressed in the near future.
 
 ## Developing
 
@@ -282,6 +281,18 @@ Recreate environment:
 ```sh
 make get-poetry
 make venv-with-dependencies
+```
+
+Run the linters:
+
+```sh
+make linters
+```
+
+Run the tests:
+
+```sh
+make tests
 ```
 
 ## Resources

--- a/asymmetric/callbacks/core.py
+++ b/asymmetric/callbacks/core.py
@@ -93,7 +93,7 @@ class CallbackClient:
             self.__get_header_finders()
         except InvalidCallbackObjectError as error:
             log(str(error), level="critical")
-            raise InvalidCallbackObjectError(error)
+            raise InvalidCallbackObjectError(error) from error
 
     def __validate_callback_json_data(self) -> None:
         """

--- a/asymmetric/callbacks/core.py
+++ b/asymmetric/callbacks/core.py
@@ -3,6 +3,7 @@ A module for asymmetric's core callback logic.
 """
 
 import asyncio
+import json
 from typing import Any, Callable, Dict, Optional, Union
 
 import httpx
@@ -14,7 +15,7 @@ from asymmetric.callbacks.utils import valid_callback_data
 from asymmetric.constants import HTTP_METHODS
 from asymmetric.errors import InvalidCallbackHeadersError, InvalidCallbackObjectError
 from asymmetric.loggers import log
-from asymmetric.utils import generic_call, terminate_program
+from asymmetric.utils import generic_call
 
 
 class CallbackClient:
@@ -91,9 +92,8 @@ class CallbackClient:
             self.__validate_callback_json_data()
             self.__get_header_finders()
         except InvalidCallbackObjectError as error:
-            self.__invalid_callback_object = str(error)
-            log(str(error), level="warn")
-            terminate_program()
+            log(str(error), level="critical")
+            raise InvalidCallbackObjectError(error)
 
     def __validate_callback_json_data(self) -> None:
         """
@@ -101,7 +101,12 @@ class CallbackClient:
         dictionary or raises an error.
         """
         if not valid_callback_data(self.__callback):
-            raise InvalidCallbackObjectError("Invalid callback object")
+            raise InvalidCallbackObjectError(
+                "Invalid callback object:\n"
+                + json.dumps(
+                    self.__callback, indent=2, sort_keys=False, ensure_ascii=False
+                )
+            )
 
     def __get_header_finders(self) -> None:
         """

--- a/asymmetric/constants.py
+++ b/asymmetric/constants.py
@@ -2,9 +2,6 @@
 A module for every constant of asymmetric.
 """
 
-# Logs
-LOG_FILE_NAME = "asymmetric.log"
-
 # HTTP related
 HTTP_METHODS = [
     "get",

--- a/asymmetric/core.py
+++ b/asymmetric/core.py
@@ -16,12 +16,7 @@ from asymmetric.endpoints import Endpoints
 from asymmetric.errors import DuplicatedEndpointError
 from asymmetric.helpers import http_verb
 from asymmetric.loggers import log, log_request
-from asymmetric.utils import (
-    filter_params,
-    generic_call,
-    get_body,
-    handle_error,
-)
+from asymmetric.utils import filter_params, generic_call, get_body, handle_error
 
 
 class Asymmetric:

--- a/asymmetric/core.py
+++ b/asymmetric/core.py
@@ -95,9 +95,9 @@ class Asymmetric:
                     function,  # Save unchanged function
                     wrapper,  # Save starlette decorated function
                 )
-            except DuplicatedEndpointError as err:
-                log(f"DuplicatedEndpointError: {err}", level="critical")
-                raise DuplicatedEndpointError(err)
+            except DuplicatedEndpointError as error:
+                log(f"DuplicatedEndpointError: {error}", level="critical")
+                raise DuplicatedEndpointError(error) from error
 
             return function
 

--- a/asymmetric/core.py
+++ b/asymmetric/core.py
@@ -21,7 +21,6 @@ from asymmetric.utils import (
     generic_call,
     get_body,
     handle_error,
-    terminate_program,
 )
 
 
@@ -102,8 +101,8 @@ class Asymmetric:
                     wrapper,  # Save starlette decorated function
                 )
             except DuplicatedEndpointError as err:
-                log(f"DuplicatedRouteError: {err}", level="error")
-                terminate_program()  # TODO: exit the server correctly
+                log(f"DuplicatedEndpointError: {err}", level="critical")
+                raise DuplicatedEndpointError(err)
 
             return function
 

--- a/asymmetric/endpoints.py
+++ b/asymmetric/endpoints.py
@@ -91,7 +91,7 @@ class Endpoints:  # pylint: disable=R0903
         and stores it.
         """
         if self.__get_endpoint(route, method) is not None:
-            message = f"Endpoint '{route}' with HTTP method '{method}' "
+            message = f"Endpoint '{route}' with HTTP method '{method.upper()}' "
             message += "was defined twice."
             raise DuplicatedEndpointError(message)
 

--- a/asymmetric/loggers.py
+++ b/asymmetric/loggers.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Dict
 
 from starlette.requests import Request
 
-from asymmetric.constants import LOG_FILE_NAME
 from asymmetric.utils import get_body
 
 # Logging configuration

--- a/asymmetric/loggers.py
+++ b/asymmetric/loggers.py
@@ -14,35 +14,39 @@ from asymmetric.constants import LOG_FILE_NAME
 from asymmetric.utils import get_body
 
 # Logging configuration
-logging.config.dictConfig(
-    {
-        "version": 1,
-        "formatters": {
-            "console": {
-                "format": "[%(asctime)s] [%(levelname)s] %(module)s: %(message)s"
-            },
-            "file": {
-                "format": (
-                    "[%(asctime)s] [%(levelname)s] %(pathname)s - "
-                    "line %(lineno)d: \n%(message)s\n"
-                )
-            },
+configuration: Dict[str, Any] = {
+    "version": 1,
+    "formatters": {
+        "console": {"format": "[%(asctime)s] [%(levelname)s] %(module)s: %(message)s"},
+        "file": {
+            "format": (
+                "[%(asctime)s] [%(levelname)s] %(pathname)s - "
+                "line %(lineno)d: \n%(message)s\n"
+            )
         },
-        "handlers": {
-            "console": {
-                "class": "logging.StreamHandler",
-                "stream": "ext://sys.stderr",
-                "formatter": "console",
-            },
-            "file": {
-                "class": "logging.FileHandler",
-                "filename": os.getenv("LOG_FILE", default=LOG_FILE_NAME),
-                "formatter": "file",
-            },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stderr",
+            "formatter": "console",
         },
-        "root": {"level": "INFO", "handlers": ["console", "file"]},
+    },
+    "root": {
+        "level": os.getenv("LOG_LEVEL", "WARNING"),
+        "handlers": ["console"],
+    },
+}
+
+if os.getenv("LOG_FILE") is not None:
+    configuration["handlers"]["file"] = {
+        "class": "logging.FileHandler",
+        "filename": os.getenv("LOG_FILE"),
+        "formatter": "file",
     }
-)
+    configuration["root"]["handlers"].append("file")
+
+logging.config.dictConfig(configuration)
 
 
 def log(message: str, level: str = "info") -> None:

--- a/asymmetric/utils.py
+++ b/asymmetric/utils.py
@@ -4,7 +4,6 @@ A module for every utility of asymmetric.
 
 import inspect
 import json
-import sys
 from typing import Any, Callable, Dict
 
 from starlette.requests import Request

--- a/asymmetric/utils.py
+++ b/asymmetric/utils.py
@@ -74,8 +74,3 @@ def valid_plain_dict(data: Dict[str, Any], validator: Dict[str, Any]) -> bool:
         return False
 
     return True
-
-
-def terminate_program() -> None:
-    """Terminates the server process."""
-    sys.exit(1)


### PR DESCRIPTION
# Fix: Fix server stops on initialization errors

## Description

The server now stops on certain initialization errors. For example, on duplicated endpoints.

## Requirements

None.

## Additional changes

Update the logging strategy, to use a logging file only if configured and to start logging on `WARN` level.